### PR TITLE
fix: Update Flask version to resolve Werkzeug incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Follow these steps to set up and run the application locally:
     ```bash
     pip install -r requirements.txt
     ```
+    *Note: If you have previously installed dependencies, it's recommended to upgrade them to ensure all package versions are compatible after recent updates:*
+    ```bash
+    pip install -r requirements.txt --upgrade
+    ```
 
 4.  **Set Environment Variables**
     This application requires two environment variables to be set:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Flask==2.0.1
+Flask~=2.3.0
 google-generativeai


### PR DESCRIPTION
Updates Flask from version 2.0.1 to ~2.3.0 in `requirements.txt`. This change addresses an `ImportError: cannot import name 'url_quote' from 'werkzeug.urls'` which occurs due to incompatibilities between older Flask versions and newer Werkzeug releases (Werkzeug >= 2.1.0).

The README.md has also been updated to advise you to upgrade your installed packages using `pip install -r requirements.txt --upgrade`.