### PR TITLE
Refactor: Update settings UI and add Tone feature

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -27,9 +27,9 @@ def configure_gemini(api_key):
             API_KEY_WARNING_PRINTED = True
         GEMINI_API_KEY_CONFIGURED = False
 
-def generate_chat_response(user_input, conversation_history, native_lang, target_lang, difficulty):
+def generate_chat_response(user_input, conversation_history, native_lang, target_lang, difficulty, tone="Serious"): # Added tone
     """
-    Generates a chat response using the Gemini model, incorporating language and difficulty settings.
+    Generates a chat response using the Gemini model, incorporating language, difficulty, and tone settings.
     """
     global GEMINI_API_KEY_CONFIGURED, API_KEY_WARNING_PRINTED
     if not GEMINI_API_KEY_CONFIGURED:
@@ -39,26 +39,25 @@ def generate_chat_response(user_input, conversation_history, native_lang, target
         return SERVICE_NOT_CONFIGURED_CHAT_MESSAGE
 
     try:
-        model = genai.GenerativeModel('gemini-2.0-flash') # Updated model name
+        model = genai.GenerativeModel('gemini-2.0-flash') 
         
         system_prompt = f"""You are a language learning tutor.
         The user's native language is {native_lang}.
         The user wants to learn {target_lang}.
         The user's current learning difficulty is {difficulty}.
+        Adapt your responses to a {tone} tone.
         Keep your responses concise and helpful for a {difficulty} learner of {target_lang}.
         Engage in a conversation in {target_lang}. If the user speaks in {native_lang}, gently guide them to use {target_lang}.
         """
 
         chat_history_for_model = []
         
-        if not conversation_history:
-             pass 
-
-
-        for exchange in conversation_history:
-            if 'user' in exchange and 'bot' in exchange:
-                 chat_history_for_model.append({"role": "user", "parts": [exchange['user']]})
-                 chat_history_for_model.append({"role": "model", "parts": [exchange['bot']]})
+        # Populate history for the model
+        if conversation_history: 
+            for exchange in conversation_history:
+                if 'user' in exchange and 'bot' in exchange: 
+                     chat_history_for_model.append({"role": "user", "parts": [str(exchange['user'])]}) 
+                     chat_history_for_model.append({"role": "model", "parts": [str(exchange['bot'])]})
 
         chat = model.start_chat(history=chat_history_for_model)
         
@@ -69,13 +68,13 @@ def generate_chat_response(user_input, conversation_history, native_lang, target
         response = chat.send_message(contextual_user_input)
         return response.text
     except Exception as e:
-        print(f"Error generating chat response from Gemini: {e}") # Log specific error
+        print(f"Error generating chat response from Gemini: {e}") 
         return CHAT_ERROR_MESSAGE
 
-def generate_feedback(last_exchange, native_lang, target_lang, difficulty):
+def generate_feedback(last_exchange, native_lang, target_lang, difficulty, tone="Serious"): # Added tone
     """
     Generates feedback on the user's part of the last exchange, 
-    considering language and difficulty.
+    considering language, difficulty, and tone.
     """
     global GEMINI_API_KEY_CONFIGURED, API_KEY_WARNING_PRINTED
     if not GEMINI_API_KEY_CONFIGURED:
@@ -85,7 +84,7 @@ def generate_feedback(last_exchange, native_lang, target_lang, difficulty):
         return SERVICE_NOT_CONFIGURED_FEEDBACK_MESSAGE
 
     try:
-        model = genai.GenerativeModel('gemini-2.0-flash') # Updated model name
+        model = genai.GenerativeModel('gemini-2.0-flash') 
         user_message = last_exchange.get('user')
         
         if not user_message:
@@ -103,7 +102,8 @@ def generate_feedback(last_exchange, native_lang, target_lang, difficulty):
         3.  Phrasing: Offer alternative phrasings for better fluency or politeness in {target_lang}.
         4.  Positive Reinforcement: Begin with encouragement.
         
-        Deliver the feedback in {native_lang}. Keep it concise and easy to understand for a {difficulty} learner.
+        Deliver the feedback in {native_lang}. Adapt your feedback to a {tone} tone, while still being constructive.
+        Keep it concise and easy to understand for a {difficulty} learner.
         If the user's message is grammatically correct and appropriate for their level, acknowledge this.
         
         Example of feedback format (translate to {native_lang} if different from English):
@@ -118,7 +118,7 @@ def generate_feedback(last_exchange, native_lang, target_lang, difficulty):
         response = model.generate_content(prompt)
         return response.text
     except Exception as e:
-        print(f"Error generating feedback from Gemini: {e}") # Log specific error
+        print(f"Error generating feedback from Gemini: {e}") 
         return FEEDBACK_ERROR_MESSAGE
 
 if os.environ.get("GEMINI_API_KEY") and not GEMINI_API_KEY_CONFIGURED:

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -5,9 +5,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const feedbackContentDiv = document.getElementById('feedback-content');
     const nativeLangSelect = document.getElementById('native-lang');
     const targetLangSelect = document.getElementById('target-lang');
+    const difficultySelect = document.getElementById('difficulty'); // Added for dropdown
+    const toneSelect = document.getElementById('tone'); // Added for tone dropdown
     const updateSettingsButton = document.getElementById('update-settings-button');
 
-    const getDifficulty = () => document.querySelector('input[name="difficulty"]:checked').value;
+    const getDifficulty = () => difficultySelect.value; // Updated to read from select
+    const getTone = () => toneSelect.value; // Added to read from tone select
 
     const BOT_ERROR_PLACEHOLDER = "Sorry, I can't respond right now. The AI service seems to be unavailable. Please try again later.";
     const FEEDBACK_ERROR_PLACEHOLDER = "No feedback available at the moment. The AI service might be temporarily down.";
@@ -98,9 +101,8 @@ document.addEventListener('DOMContentLoaded', () => {
             if (data.settings) {
                 nativeLangSelect.value = data.settings.native_lang || 'English';
                 targetLangSelect.value = data.settings.target_lang || 'Spanish';
-                document.querySelectorAll('input[name="difficulty"]').forEach(radio => {
-                    radio.checked = radio.value === (data.settings.difficulty || 'Beginner');
-                });
+                difficultySelect.value = data.settings.difficulty || 'Beginner'; // Updated for dropdown
+                toneSelect.value = data.settings.tone || 'Serious'; // Added for tone
             }
 
         } catch (error) {
@@ -119,6 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const nativeLang = nativeLangSelect.value;
         const targetLang = targetLangSelect.value;
         const difficulty = getDifficulty();
+        const currentTone = getTone(); // Get current tone
 
         displayMessage('user', messageText);
         messageInput.value = ''; 
@@ -136,6 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     native_lang: nativeLang,
                     target_lang: targetLang,
                     difficulty: difficulty,
+                    tone: currentTone, // Added tone to payload
                 }),
             });
 
@@ -191,6 +195,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const nativeLang = nativeLangSelect.value;
         const targetLang = targetLangSelect.value;
         const difficulty = getDifficulty();
+        const currentTone = getTone(); // Get current tone
 
         // You could add visual feedback for settings update too
         updateSettingsButton.textContent = 'Updating...';
@@ -204,6 +209,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     native_lang: nativeLang,
                     target_lang: targetLang,
                     difficulty: difficulty,
+                    tone: currentTone, // Added tone to payload
                 }),
             });
             if (!response.ok) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,15 +37,21 @@
                 </select>
             </div>
             <div>
-                <label>Difficulty:</label>
-                <div class="difficulty-options"> {/* Added wrapper for styling */}
-                    <input type="radio" id="beginner" name="difficulty" value="Beginner" {% if settings.difficulty == 'Beginner' %}checked{% endif %}>
-                    <label for="beginner">Beginner</label>
-                    <input type="radio" id="intermediate" name="difficulty" value="Intermediate" {% if settings.difficulty == 'Intermediate' %}checked{% endif %}>
-                    <label for="intermediate">Intermediate</label>
-                    <input type="radio" id="advanced" name="difficulty" value="Advanced" {% if settings.difficulty == 'Advanced' %}checked{% endif %}>
-                    <label for="advanced">Advanced</label>
-                </div>
+                <label for="difficulty">Difficulty:</label> {# Changed label to point to select ID #}
+                <select id="difficulty" name="difficulty">
+                    <option value="Beginner" {% if settings.difficulty == 'Beginner' %}selected{% endif %}>Beginner</option>
+                    <option value="Intermediate" {% if settings.difficulty == 'Intermediate' %}selected{% endif %}>Intermediate</option>
+                    <option value="Advanced" {% if settings.difficulty == 'Advanced' %}selected{% endif %}>Advanced</option>
+                </select>
+            </div>
+            <div>
+                <label for="tone">Tone:</label>
+                <select id="tone" name="tone">
+                    <option value="Serious" {% if settings.tone == 'Serious' %}selected{% endif %}>Serious</option>
+                    <option value="Romantic" {% if settings.tone == 'Romantic' %}selected{% endif %}>Romantic</option>
+                    <option value="Sarcastic" {% if settings.tone == 'Sarcastic' %}selected{% endif %}>Sarcastic</option>
+                    <option value="Neutral" {% if settings.tone == 'Neutral' %}selected{% endif %}>Neutral</option>
+                </select>
             </div>
             <button id="update-settings-button">Update Settings</button>
         </div>


### PR DESCRIPTION
This commit introduces the following changes:

- Replaces the difficulty radio buttons with a dropdown menu for a cleaner UI.
- Adds a new "Tone" setting (Serious, Romantic, Sarcastic, Neutral) as a dropdown menu.
- Updates backend (Flask server) to handle the new "Tone" setting in session management, chat processing, and settings updates.
- Modifies the LLM interaction logic to incorporate the selected "Tone" into prompts for chat responses and feedback generation.
- Updates frontend JavaScript to manage the new dropdowns and include the "Tone" in requests.
- Ensures default values are handled correctly and settings are persisted across sessions.

The UI is now cleaner, and you have more control over the interaction style with the language learning bot.